### PR TITLE
:bug: Fix TikTok flags

### DIFF
--- a/scheduler-service/src/app/controllers/tiktokController.js
+++ b/scheduler-service/src/app/controllers/tiktokController.js
@@ -1,6 +1,4 @@
-const fs = require("fs");
 const axios = require("axios");
-const FormData = require("form-data");
 const platformConnection = require("../models/platformConnection");
 
 // Internal method for posting videos to TikTok (used by scheduler)
@@ -41,9 +39,9 @@ exports.postTikTokVideoInternal = async ({
           post_info: {
             title: content,
             privacy_level: tiktokSettings.viewerSetting,
-            disable_duet: tiktokSettings.allowDuet,
-            disable_comment: tiktokSettings.allowComments,
-            disable_stitch: tiktokSettings.allowStitch,
+            disable_duet: !tiktokSettings.allowDuet,
+            disable_comment: !tiktokSettings.allowComments,
+            disable_stitch: !tiktokSettings.allowStitch,
             video_cover_timestamp_ms: Math.round(
               post.postGroupId.videoTimestamp * 1000
             ),


### PR DESCRIPTION
## Summary

This PR resolves an issue with TikTok API settings where BrandCraft model stores positive boolean values (e.g., true for enabling a feature), but TikTok's API expects negative values (e.g., `disable_comment: true` means comments are disabled). It also removes unused imports.